### PR TITLE
Remove redundant binfmt_misc_64 command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN CC=clang CXX=clang++ cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Re
 RUN ninja
 RUN ninja install
 RUN ninja binfmt_misc
-RUN ninja binfmt_misc_64
 
 # Create user steam
 RUN useradd -m steam


### PR DESCRIPTION
Prevents builds failing with this error:
`0.097 ninja: error: unknown target 'binfmt_misc_64', did you mean 'binfmt_misc'?`

Full log:

```
➜  satisfactory-server git:(869dcfb) ✗ ./build.sh
[+] Building 318.8s (22/28)                                                                                                                                               docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                0.0s
 => => transferring dockerfile: 1.96kB                                                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.04                                                                                                                     2.7s
 => [internal] load .dockerignore                                                                                                                                                   0.0s
 => => transferring context: 2B                                                                                                                                                     0.0s
 => [ 1/24] FROM docker.io/library/ubuntu:22.04@sha256:4e0171b9275e12d375863f2b3ae9ce00a4c53ddda176bd55868df97ac6f21a6e                                                             2.6s
 => => resolve docker.io/library/ubuntu:22.04@sha256:4e0171b9275e12d375863f2b3ae9ce00a4c53ddda176bd55868df97ac6f21a6e                                                               0.0s
 => => sha256:4e0171b9275e12d375863f2b3ae9ce00a4c53ddda176bd55868df97ac6f21a6e 6.69kB / 6.69kB                                                                                      0.0s
 => => sha256:4fbb08094ffa2d7a1ae4d0c6d1a5a4da82034841ecf1391e00e645061307edc6 424B / 424B                                                                                          0.0s
 => => sha256:d2b493e1373bfeb802433261f9ae11dfa3fe1af182706d9768074c20a92329a7 2.31kB / 2.31kB                                                                                      0.0s
 => => sha256:fdf67ba0bcdcbe417cffb2808175ef408d653d78cb464d1917e84ba0f40ef5de 27.36MB / 27.36MB                                                                                    1.9s
 => => extracting sha256:fdf67ba0bcdcbe417cffb2808175ef408d653d78cb464d1917e84ba0f40ef5de                                                                                           0.6s
 => [internal] load build context                                                                                                                                                   0.0s
 => => transferring context: 1.30kB                                                                                                                                                 0.0s
 => [ 2/24] RUN apt update && apt install -y curl python3 sudo expect-dev software-properties-common                                                                               25.8s
 => [ 3/24] RUN apt install -y squashfs-tools squashfuse git python-setuptools pkgconf clang                                                                                       26.4s
 => [ 4/24] RUN apt install -y binfmt-support systemd cmake ninja-build software-properties-common                                                                                  5.8s
 => [ 5/24] RUN apt install -y libncurses6 libncurses5 libtinfo5 libtinfo6 libncurses-dev                                                                                           2.5s
 => [ 6/24] RUN apt install -y libsdl2-dev libepoxy-dev libssl-dev llvm lld                                                                                                        45.4s
 => [ 7/24] RUN apt install -y qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5core5a libqt5gui5 libqt5widgets5 qtdeclarative5-dev qml-module-qtquick2 qml-module-qtquick  32.7s
 => [ 8/24] RUN add-apt-repository -y ppa:fex-emu/fex                                                                                                                              11.0s
 => [ 9/24] RUN git clone --recurse-submodules https://github.com/FEX-Emu/FEX.git                                                                                                  86.1s
 => [10/24] WORKDIR FEX                                                                                                                                                             0.0s
 => [11/24] RUN sed -i 's@USE_LEGACY_BINFMTMISC "Uses legacy method of setting up binfmt_misc" FALSE@USE_LEGACY_BINFMTMISC "Uses legacy method of setting up binfmt_misc" TRUE@' .  0.1s
 => [12/24] RUN mkdir Build                                                                                                                                                         0.1s
 => [13/24] WORKDIR Build                                                                                                                                                           0.0s
 => [14/24] RUN CC=clang CXX=clang++ cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -DUSE_LINKER=lld -DENABLE_LTO=True -DBUILD_TESTS=False -DENABLE_ASSERTIONS=False  4.5s
 => [15/24] RUN ninja                                                                                                                                                              72.5s
 => [16/24] RUN ninja install                                                                                                                                                       0.2s
 => [17/24] RUN ninja binfmt_misc                                                                                                                                                   0.2s
 => ERROR [18/24] RUN ninja binfmt_misc_64                                                                                                                                          0.1s
------
 > [18/24] RUN ninja binfmt_misc_64:
0.084 [0/2] Re-checking globbed directories...
0.097 ninja: error: unknown target 'binfmt_misc_64', did you mean 'binfmt_misc'?
------

 2 warnings found (use docker --debug to expand):
 - WorkdirRelativePath: Relative workdir "FEX" can have unexpected results if the base image changes (line 17)
 - JSONArgsRecommended: JSON arguments recommended for ENTRYPOINT to prevent unintended behavior related to OS signals (line 47)
Dockerfile:25
--------------------
  23 |     RUN ninja install
  24 |     RUN ninja binfmt_misc
  25 | >>> RUN ninja binfmt_misc_64
  26 |     
  27 |     # Create user steam
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c ninja binfmt_misc_64" did not complete successfully: exit code: 1
```