### PR TITLE
Define ownership for Steam directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ RUN useradd -m steam
 # InstallL FEX root FS
 RUN sudo -u steam bash -c "unbuffer FEXRootFSFetcher -y -x"
 
+# Explicitly define steam directory ownership
+RUN mkdir -p /home/steam/Steam && chown -R steam:steam /home/steam/Steam
+
 # Change user to steam
 USER steam
 


### PR DESCRIPTION
Unsure of what the cause is, but in some cases, there are users that can't build using `sh build.sh` as it outputs a internal docker error (#13). This fixes the internal permission garble by forcing the root to make the directory and force the steam user to be able to use the directory.